### PR TITLE
Default: 특강 신청/목록 기본 기능 구현 & 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,39 +1,47 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.4'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.4'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.brlee'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
-}
-
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Spring Boot Web (REST API 개발)
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Spring Data JPA (JPA 및 Hibernate 사용)
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Spring Boot Validation (유효성 검사)
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Lombok 의존성 추가
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // MySQL JDBC Driver (MySQL 데이터베이스 연결)
+    runtimeOnly 'mysql:mysql-connector-java:8.0.32'
+
+    // 테스트 의존성 - JUnit 5 및 Spring Boot Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    
+    // JUnit 5 의존성
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/brlee/lecture/controller/LectureController.java
+++ b/src/main/java/com/brlee/lecture/controller/LectureController.java
@@ -1,0 +1,80 @@
+package com.brlee.lecture.controller;
+
+import com.brlee.lecture.dto.LectureRequestDto;
+import com.brlee.lecture.dto.LectureResponseDto;
+import com.brlee.lecture.service.LectureService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+// 추가
+
+@RestController
+@RequestMapping("/api/lectures")
+public class LectureController {
+
+    private final LectureService lectureService;
+
+    public LectureController(LectureService lectureService) {
+        this.lectureService = lectureService;
+    }
+
+    /**
+     * 특강 신청 API
+     * @param requestDto - 신청 정보 (특강 ID, 사용자 ID)
+     * @return 신청 성공 여부에 따른 메시지
+     */
+    @PostMapping("/apply")
+    public ResponseEntity<String> applyForLecture(@RequestBody LectureRequestDto requestDto) {
+        try {
+            boolean isApplied = lectureService.applyForLecture(requestDto.getLectureId(), requestDto.getUserId());
+
+            if (isApplied) {
+                return ResponseEntity.ok("강의 신청이 완료 되었습니다.");
+            } else {
+                return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 신청한 강의 입니다.");
+            }
+        } catch (IllegalStateException e) {
+            // 정원이 찬 경우 처리
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            // 특강이 존재하지 않는 경우 처리
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    /**
+     * 신청한 특강 목록 조회 API
+     * @param userId - 조회할 사용자 ID
+     * @return 해당 사용자가 신청한 특강 목록
+     */
+    @GetMapping("/applied/{userId}")
+    public ResponseEntity<List<LectureResponseDto>> getAppliedLectures(@PathVariable Long userId) {
+        List<LectureResponseDto> lectures = lectureService.getAppliedLectures(userId);
+        return ResponseEntity.ok(lectures);
+    }
+
+    /**
+     * 현재 신청 가능한 특강 목록 조회 API
+     * @return 신청 가능한 특강 목록
+     */
+    @GetMapping("/list")
+    public ResponseEntity<List<LectureResponseDto>> getAvailableLectures() {
+        List<LectureResponseDto> lectures = lectureService.getAvailableLectures();
+        return ResponseEntity.ok(lectures);
+    }
+
+    /**
+     * 날짜별 신청 가능한 특강 목록 조회 API
+     * @param date - 조회할 날짜 (형식: YYYY-MM-DD)
+     * @return 신청 가능한 특강 목록
+     */
+    @GetMapping("/available")
+    public ResponseEntity<List<LectureResponseDto>> getAvailableLecturesByDate(@RequestParam("date") LocalDate date) {
+        List<LectureResponseDto> lectures = lectureService.getAvailableLecturesByDate(date);
+        return ResponseEntity.ok(lectures);
+    }
+}

--- a/src/main/java/com/brlee/lecture/dto/LectureRequestDto.java
+++ b/src/main/java/com/brlee/lecture/dto/LectureRequestDto.java
@@ -1,0 +1,15 @@
+package com.brlee.lecture.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// 추가
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LectureRequestDto {
+    private Long lectureId;
+    private Long userId;
+}

--- a/src/main/java/com/brlee/lecture/dto/LectureResponseDto.java
+++ b/src/main/java/com/brlee/lecture/dto/LectureResponseDto.java
@@ -1,0 +1,29 @@
+package com.brlee.lecture.dto;
+
+import com.brlee.lecture.entity.Lecture;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// 추가
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LectureResponseDto {
+    private Long id;
+    private String title;
+    private String lecturer;
+    private String date; // 문자열로 변경하거나 LocalDate로 사용 가능
+    private int maxCapacity;
+    private int currentApplicants;
+
+    public LectureResponseDto(Lecture lecture) {
+        this.id = lecture.getId();
+        this.title = lecture.getTitle();
+        this.lecturer = lecture.getLecturer();
+        this.date = lecture.getDate().toString();
+        this.maxCapacity = lecture.getMaxCapacity();
+        this.currentApplicants = lecture.getCurrentApplicants();
+    }
+}

--- a/src/main/java/com/brlee/lecture/entity/Lecture.java
+++ b/src/main/java/com/brlee/lecture/entity/Lecture.java
@@ -1,0 +1,29 @@
+package com.brlee.lecture.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// 추가
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Lecture {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String lecturer;
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private int maxCapacity = 30;
+
+    @Column(nullable = false)
+    private int currentApplicants = 0;
+}

--- a/src/main/java/com/brlee/lecture/entity/UserLecture.java
+++ b/src/main/java/com/brlee/lecture/entity/UserLecture.java
@@ -1,0 +1,30 @@
+package com.brlee.lecture.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// 추가
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class UserLecture {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "lecture_id")
+    private Lecture lecture;
+
+    private Long userId;
+
+    // 특정 필드를 받는 생성자 추가
+    public UserLecture(Lecture lecture, Long userId) {
+        this.lecture = lecture;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/brlee/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/brlee/lecture/repository/LectureRepository.java
@@ -1,0 +1,22 @@
+package com.brlee.lecture.repository;
+
+import com.brlee.lecture.entity.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+// 추가
+
+@Repository
+public interface LectureRepository extends JpaRepository<Lecture, Long> {
+
+    /**
+     * 날짜별로 현재 신청 가능한 특강 목록 조회 (신청 인원이 정원보다 적은 특강만)
+     * @param date - 조회할 날짜
+     * @param maxCapacity - 최대 수강 가능 인원
+     * @return 신청 가능한 특강 목록
+     */
+    List<Lecture> findAllByDateAndCurrentApplicantsLessThan(LocalDate date, int maxCapacity);
+}

--- a/src/main/java/com/brlee/lecture/repository/UserLectureRepository.java
+++ b/src/main/java/com/brlee/lecture/repository/UserLectureRepository.java
@@ -1,0 +1,15 @@
+package com.brlee.lecture.repository;
+
+import com.brlee.lecture.entity.UserLecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+// 추가
+
+@Repository
+public interface UserLectureRepository extends JpaRepository<UserLecture, Long> {
+    boolean existsByUserIdAndLectureId(Long userId, Long lectureId);
+    List<UserLecture> findByUserId(Long userId);
+}

--- a/src/main/java/com/brlee/lecture/service/LectureService.java
+++ b/src/main/java/com/brlee/lecture/service/LectureService.java
@@ -1,0 +1,101 @@
+package com.brlee.lecture.service;
+
+import com.brlee.lecture.entity.Lecture;
+import com.brlee.lecture.entity.UserLecture;
+import com.brlee.lecture.dto.LectureResponseDto;
+import com.brlee.lecture.repository.LectureRepository;
+import com.brlee.lecture.repository.UserLectureRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+// 추가
+
+@Service
+public class LectureService {
+
+    private final LectureRepository lectureRepository;
+    private final UserLectureRepository userLectureRepository;
+
+    public LectureService(LectureRepository lectureRepository, UserLectureRepository userLectureRepository) {
+        this.lectureRepository = lectureRepository;
+        this.userLectureRepository = userLectureRepository;
+    }
+
+    /**
+     * 특강 신청 로직 (동시성 이슈 방지)
+     * @param lectureId - 신청할 특강 ID
+     * @param userId - 신청하는 사용자 ID
+     * @return 신청 성공 여부
+     */
+    @Transactional
+    public synchronized boolean applyForLecture(Long lectureId, Long userId) {
+        // 특강 조회
+        Optional<Lecture> lectureOpt = lectureRepository.findById(lectureId);
+        if (lectureOpt.isEmpty()) {
+            throw new IllegalArgumentException("강의를 찾을 수 없습니다.");
+        }
+
+        Lecture lecture = lectureOpt.get();
+
+        // 특강 신청 인원이 30명 이상인 경우 실패
+        if (lecture.getCurrentApplicants() >= lecture.getMaxCapacity()) {
+            throw new IllegalStateException("이미 강의 신청 인원이 30명 입니다.");
+        }
+
+        // 사용자가 이미 해당 특강을 신청했는지 확인
+        if (userLectureRepository.existsByUserIdAndLectureId(userId, lectureId)) {
+            return false;
+        }
+
+        // 특강 신청 처리
+        lecture.setCurrentApplicants(lecture.getCurrentApplicants() + 1);
+        UserLecture userLecture = new UserLecture(lecture, userId);
+        userLectureRepository.save(userLecture);
+        lectureRepository.save(lecture);
+
+        return true;
+    }
+
+    /**
+     * 사용자가 신청한 특강 목록 조회
+     * @param userId - 조회할 사용자 ID
+     * @return 신청한 특강 목록
+     */
+    @Transactional(readOnly = true)
+    public List<LectureResponseDto> getAppliedLectures(Long userId) {
+        List<UserLecture> userLectures = userLectureRepository.findByUserId(userId);
+        return userLectures.stream()
+                .map(userLecture -> new LectureResponseDto(userLecture.getLecture()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 신청 가능한 특강 목록 조회
+     * @return 신청 가능한 특강 목록
+     */
+    @Transactional(readOnly = true)
+    public List<LectureResponseDto> getAvailableLectures() {
+        List<Lecture> lectures = lectureRepository.findAll();
+        return lectures.stream()
+                .map(LectureResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 날짜별 신청 가능한 특강 목록 조회
+     * @param date - 조회할 날짜
+     * @return 신청 가능한 특강 목록
+     */
+    @Transactional(readOnly = true)
+    public List<LectureResponseDto> getAvailableLecturesByDate(LocalDate date) {
+        List<Lecture> lectures = lectureRepository.findAllByDateAndCurrentApplicantsLessThan(date, 30);
+        return lectures.stream()
+                .map(LectureResponseDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/brlee/lecture/service/LectureServiceTest.java
+++ b/src/main/java/com/brlee/lecture/service/LectureServiceTest.java
@@ -1,0 +1,224 @@
+package com.brlee.lecture.service;
+
+import com.brlee.lecture.dto.LectureResponseDto;
+import com.brlee.lecture.entity.Lecture;
+import com.brlee.lecture.entity.UserLecture;
+import com.brlee.lecture.repository.LectureRepository;
+import com.brlee.lecture.repository.UserLectureRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.ArrayList;
+
+
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class LectureServiceTest {
+
+	@InjectMocks
+	private LectureService lectureService;
+
+	@Mock
+	private LectureRepository lectureRepository;
+
+	@Mock
+	private UserLectureRepository userLectureRepository;
+
+	private Lecture lecture;
+	private final Long lectureId = 1L;
+	private final Long userId = 1L;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this); // Mock 객체 초기화
+		lecture = new Lecture();
+		lecture.setId(lectureId);
+		lecture.setTitle("Spring Boot 특강");
+		lecture.setLecturer("John Doe");
+		lecture.setMaxCapacity(30);
+		lecture.setCurrentApplicants(10);  // 현재 신청 인원 설정
+		lecture.setDate(LocalDate.of(2024, 10, 10)); // 날짜 필드 설정
+	}
+
+	/**
+	 * 성공 케이스 테스트
+	 */
+	@Test
+	void applyForLecture_Success() {
+		// given
+		when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+		when(userLectureRepository.existsByUserIdAndLectureId(userId, lectureId)).thenReturn(false);
+
+		// when
+		boolean result = lectureService.applyForLecture(lectureId, userId);
+
+		// then
+		assertTrue(result);  // 신청 성공
+		verify(lectureRepository, times(1)).save(lecture);
+		verify(userLectureRepository, times(1)).save(any(UserLecture.class));
+		assertEquals(11, lecture.getCurrentApplicants());  // 신청 인원 증가 확인
+	}
+
+	/**
+	 * 동일 신청자가 두 번 신청하면 막아야 되는 케이스 테스트
+	 */
+	@Test
+	void applyForLecture_DuplicateApplication_Fail() {
+		// given
+		when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+		when(userLectureRepository.existsByUserIdAndLectureId(userId, lectureId)).thenReturn(true);  // 이미 신청한 경우
+
+		// when
+		boolean result = lectureService.applyForLecture(lectureId, userId);
+
+		// then
+		assertFalse(result);  // 신청 실패
+		verify(lectureRepository, never()).save(lecture);  // 중복 신청이므로 저장하지 않음
+		verify(userLectureRepository, never()).save(any(UserLecture.class));
+	}
+
+	/**
+	 * 정원 초과 시 신청 실패 케이스 테스트
+	 */
+	@Test
+	void applyForLecture_OverCapacity_Fail() {
+		// given
+		lecture.setCurrentApplicants(30);  // 정원이 다 찬 경우
+		when(lectureRepository.findById(lectureId)).thenReturn(Optional.of(lecture));
+		when(userLectureRepository.existsByUserIdAndLectureId(userId, lectureId)).thenReturn(false);
+
+		// when
+		IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+			lectureService.applyForLecture(lectureId, userId);
+		});
+
+		// then
+		assertEquals("이미 강의 신청 인원이 30명 입니다.", exception.getMessage());  // 정원 초과 메시지 확인
+		verify(lectureRepository, never()).save(lecture);  // 정원이 다 찼으므로 저장하지 않음
+		verify(userLectureRepository, never()).save(any(UserLecture.class));
+	}
+
+	/**
+	 * 존재하지 않는 강의 신청 시 예외 처리 테스트
+	 */
+	@Test
+	 void applyForLecture_LectureNotFound_Exception() {
+		// given
+		when(lectureRepository.findById(lectureId)).thenReturn(Optional.empty());  // 강의가 없는 경우
+
+		// when
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			lectureService.applyForLecture(lectureId, userId);
+		});
+
+		// then
+		assertEquals("강의를 찾을 수 없습니다.", exception.getMessage());  // 강의가 없다는 메시지 확인
+		verify(lectureRepository, never()).save(lecture);  // 강의가 없으므로 저장하지 않음
+		verify(userLectureRepository, never()).save(any(UserLecture.class));
+	}
+
+	@Test
+	void getAvailableLecturesByDate_NoFullCapacityLectures() {
+		// given
+		LocalDate date = LocalDate.of(2024, 10, 10);
+
+		// 신청 가능한 특강 (정원 미달)
+		Lecture availableLecture = new Lecture();
+		availableLecture.setId(1L);
+		availableLecture.setTitle("Java Spring 특강");
+		availableLecture.setLecturer("Jane Doe");
+		availableLecture.setDate(date);
+		availableLecture.setMaxCapacity(30);
+		availableLecture.setCurrentApplicants(20); // 정원 미달
+
+		// 정원이 꽉 찬 특강
+		Lecture fullLecture = new Lecture();
+		fullLecture.setId(2L);
+		fullLecture.setTitle("Docker 특강");
+		fullLecture.setLecturer("John Smith");
+		fullLecture.setDate(date);
+		fullLecture.setMaxCapacity(30);
+		fullLecture.setCurrentApplicants(30); // 정원이 다 찬 상태
+
+		// 리스트에 추가
+		List<Lecture> lectures = new ArrayList<>();
+		lectures.add(availableLecture);
+		lectures.add(fullLecture);
+
+		when(lectureRepository.findAllByDateAndCurrentApplicantsLessThan(date, 30))
+				.thenReturn(List.of(availableLecture)); // 정원이 꽉찬 특강 제외한 목록 반환
+
+		// when
+		List<LectureResponseDto> result = lectureService.getAvailableLecturesByDate(date);
+
+		// then
+		assertEquals(1, result.size());  // 정원이 꽉찬 특강 제외한 1개만 반환
+		assertEquals(availableLecture.getTitle(), result.get(0).getTitle());
+		assertEquals(availableLecture.getLecturer(), result.get(0).getLecturer());
+		verify(lectureRepository, times(1)).findAllByDateAndCurrentApplicantsLessThan(date, 30);
+	}
+
+	/**
+	 * 신청 가능한 특강이 없는 경우 테스트
+	 */
+	@Test
+	void getAvailableLecturesByDate_NoAvailableLectures() {
+		// given
+		LocalDate date = LocalDate.of(2024, 10, 10);
+
+		// 해당 날짜에 신청 가능한 특강이 없는 경우
+		when(lectureRepository.findAllByDateAndCurrentApplicantsLessThan(date, 30))
+				.thenReturn(new ArrayList<>());  // 빈 리스트 반환
+
+		// when
+		List<LectureResponseDto> result = lectureService.getAvailableLecturesByDate(date);
+
+		// then
+		assertTrue(result.isEmpty());  // 신청 가능한 특강이 없으므로 결과가 빈 리스트여야 함
+		verify(lectureRepository, times(1)).findAllByDateAndCurrentApplicantsLessThan(date, 30);
+	}
+	/**
+	 * 수강 신청 완료된 특강 목록 조회 - 신청된 특강이 있을 경우
+	 */
+	@Test
+	void getAppliedLectures_UserHasAppliedLectures() {
+		// given
+		UserLecture userLecture = new UserLecture(lecture, userId);  // 사용자와 연결된 특강
+		List<UserLecture> appliedLectures = List.of(userLecture);  // 사용자 신청 목록
+
+		when(userLectureRepository.findByUserId(userId)).thenReturn(appliedLectures);
+
+		// when
+		List<LectureResponseDto> result = lectureService.getAppliedLectures(userId);
+
+		// then
+		assertEquals(1, result.size());  // 사용자가 신청한 특강이 1개
+		assertEquals(lecture.getTitle(), result.get(0).getTitle());  // 제목이 같은지 확인
+		assertEquals(lecture.getLecturer(), result.get(0).getLecturer());  // 강사가 같은지 확인
+		verify(userLectureRepository, times(1)).findByUserId(userId);  // Repository 호출 확인
+	}
+
+	/**
+	 * 수강 신청 완료된 특강 목록 조회 - 신청된 특강이 없을 경우
+	 */
+	@Test
+	void getAppliedLectures_UserHasNoAppliedLectures() {
+		// given
+		when(userLectureRepository.findByUserId(userId)).thenReturn(new ArrayList<>());  // 신청된 특강이 없음
+
+		// when
+		List<LectureResponseDto> result = lectureService.getAppliedLectures(userId);
+
+		// then
+		assertTrue(result.isEmpty());  // 신청된 특강이 없으므로 빈 리스트여야 함
+		verify(userLectureRepository, times(1)).findByUserId(userId);  // Repository 호출 확인
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,18 @@
 spring.application.name=lecture
+
+# 애플리케이션 이름
+spring.application.name=posts
+
+# 서버 주소
+server.address=0.0.0.0
+
+# 데이터베이스 연결 설정
+spring.datasource.url=jdbc:mysql://localhost:3306/posts
+spring.datasource.username=brlee
+spring.datasource.password=brlee!@34
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# JPA 및 Hibernate 설정
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
 **완료 기능**
--------------------------------------------------------------------------------------------------------------
> 특강 조회 // DB에 없는 특강은 "강의를 찾을 수 없습니다." 반환
> 특강 신청 제한 // lecture 테이블에 max_capacity, current_applicants 컬럼 추가 후 값 비교
> 특강 신청 확인 // user_lecture 테이블에서 특강 id 값과 유저 id 값 확인
> 특강 신청 처리 // 신청 완료 후 user_lecture 테이블에 데이터 저장
> 신청 가능 목록 조회 // 현재 특강 리스트 조회
> 날짜별 가능 목록 조회 // 조회 날짜와 현재 수강인원 확인 후 30명 미만이면 조회

 **테스트 완료**
--------------------------------------------------------------------------------------------------------------
> 특강 신청
 - 신청 성공
 - 동일 신청자 두번 신청 시 실패
 - 정원(30명) 초과시 신청 실패
 - 존재 하지 않은 강의 실패
 
> 신청 가능한 특강 목록 조회
 - 정원이 꽉찬 특강은 조회 실패
 - 해당 날짜에 신청 가능한 특강이 없으시면 조회 실패

> 특강 신청 완료 목록 조회
 - 신청 된 특강이 있는 경우
 - 신청 된 특강이 없는 경우 

 **궁금 한점**
--------------------------------------------------------------------------------------------------------------
 > 수강 정보 관리 방식
 1. 수강 인원 int 로 저장 (현재 개발 방식)
 2. 수강생 정보를 저장(이름, 주소 등등)
-> 현재 개발 방식은 지금은 문제가 없지만 나중에 기능 추가 시 문제가 발생하고, 데이터 정합성 검증이 어려울 거 같은데, 실 환경에서는 강의별로 테이블 쪼개고 테이블 별로 수강생 정보를 넣는게 맞는지... 궁금 합니다.